### PR TITLE
build(scripts): :hammer: add cf -> json after synth

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "predia": "npm run cdk synth",
+    "yamlOutput": "node ./scripts/parse-cf-json-to-yaml.js",
+    "predia": "npm run cdk synth && npm run yamlOutput",
     "dia": "cdk-dia ",
     "dia:watch": "nodemon --watch bin --watch lib -e js,ts --exec \"npm run dia\""
   },

--- a/scripts/parse-cf-json-to-yaml.js
+++ b/scripts/parse-cf-json-to-yaml.js
@@ -1,0 +1,29 @@
+const { serialize } = require('aws-cdk/lib/util/yaml-cfn')
+const { readFile, readdir, writeFile } = require('fs/promises')
+const { resolve } = require('path')
+
+const dir = resolve(__dirname, '..')
+const cdkOutDir = resolve(dir, 'cdk.out')
+
+const main = async () => {
+    try {
+        const fileNames = await readdir(cdkOutDir)
+        await Promise.all(
+            fileNames
+            .filter(fileName => fileName.endsWith('.template.json'))
+            .map(async fileName => {
+                const fullFilePath = resolve(cdkOutDir, fileName)
+                const fileContent = await readFile(fullFilePath)
+                const json = JSON.parse(fileContent)
+                const yaml = serialize(json)
+                
+                const yamlFileName = fileName.replace('.json', '.yml')
+                const yamlFilePath = resolve(cdkOutDir, yamlFileName)
+                return writeFile(yamlFilePath, yaml)
+            })
+        )
+    } catch(err) {
+        console.log(err)
+    }
+}
+main()


### PR DESCRIPTION
for an easier human readable parsing of the generated templates, it's best to convert the json into yaml, which is also the most common way of writing the templates by hand