### PR TITLE
feat(config): :rocket: add devcontainer settings for workspace

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "dockerFile": "./Dockerfile",
+  "postStartCommand": "npm run dia:watch",
+  "initializeCommand": "npm install",
+  "extensions": [
+    "ms-azuretools.vscode-docker",
+    "pkief.material-icon-theme",
+    "mhutchie.git-graph",
+    "eamodio.gitlens",
+    "esbenp.prettier-vscode",
+    "vivaxy.vscode-conventional-commits"
+  ]
+}


### PR DESCRIPTION
VsCode has a really cool adddition called [devcontainers](https://code.visualstudio.com/docs/remote/containers) that acts very similar to gitpod, in that it allows you to specify an environment needed for the code in a project to be run.

This allows 2 main things I think are cool:
1. When users clone this code locally, vscode can automatically open the code in a docker container with the needed env packages.
2. Github has a gitpod alternative called codespaces that uses this 'devcontainer' concept also.

So adding this feature kills 2 birds with 1 stone in my opinion and keeps this project flexible for users longer term by allowing them to play with this anywhere they want.

Resources related to this commit:
- [devcontainers](https://code.visualstudio.com/docs/remote/containers)
- [devcontainer config](https://code.visualstudio.com/docs/remote/create-dev-container)
- [ms-devcontainers-github-examples](https://github.com/microsoft/vscode-dev-containers)
- [clone github project in a container](https://www.youtube.com/watch?v=Uvf2FVS1F8k)